### PR TITLE
Fix portrait tweak button disabling when landscape

### DIFF
--- a/index.js
+++ b/index.js
@@ -1090,7 +1090,7 @@ bot.on("interactionCreate", async (interaction) => {
           if (newJob.width===defaultSize&&newJob.height===(defaultSize+192)){tweakResponse.components[0].components[0].disabled=true}
           if (newJob.width===newJob.height){tweakResponse.components[0].components[1].disabled=true}
           //if (newJob.width===704&&newJob.height===512){tweakResponse.components[0].components[2].disabled=true}
-          if (newJob.height===defaultSize&&newJob.width===(defaultSize+192)){tweakResponse.components[0].components[0].disabled=true}
+          if (newJob.height===defaultSize&&newJob.width===(defaultSize+192)){tweakResponse.components[0].components[2].disabled=true}
           if (newJob.scale<=1){tweakResponse.components[1].components[0].disabled=true}
           if (newJob.scale>=30){tweakResponse.components[1].components[1].disabled=true}
           if (newJob.steps<=5){tweakResponse.components[1].components[2].disabled=true}


### PR DESCRIPTION
Before this fix, the bot would disable the portrait tweak button when in landscape. So you'd have to go into square first then it'd become available. It was a small typo in the code.